### PR TITLE
Fix mobile menu icon height

### DIFF
--- a/src/components/NavBar/Navbar.jsx
+++ b/src/components/NavBar/Navbar.jsx
@@ -83,7 +83,7 @@ const Navbar = () => {
             ref={closeRef}
             src={toggle ? close : menu}
             alt="menu"
-            className="w-[28px] h-[h-28px] cursor-pointer object-contain"
+            className="w-[28px] h-[28px] cursor-pointer object-contain"
             onClick={() => {
               setToggle(!toggle);
               sendGAEvent("menu_toggled", {


### PR DESCRIPTION
## Summary
- fix incorrect height class for mobile menu toggle icon in NavBar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)

------
https://chatgpt.com/codex/tasks/task_e_68bf159faed0832e95c457b28c9e9ece