### PR TITLE
Emphasize job-seeking over freelance messaging

### DIFF
--- a/src/data/contact.js
+++ b/src/data/contact.js
@@ -1,6 +1,6 @@
 export const contactTitle = {
   title: "Contact",
-  subtitle: "Get in touch",
+  subtitle: "Let's talk about job opportunities",
 };
 
 export const contactFormFields = {

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -147,7 +147,7 @@ export const events = [
       "Learn new technologies such as Android development, web development with React, Vite, Tailwind CSS, and more.",
       "Build fun and interesting projects in my free time.",
       "Participate in code reviews and provide constructive feedback to other developers.",
-      "Freelance when there is clientele.",
+      "Actively seeking full-time opportunities.",
     ],
   },
 ];

--- a/src/data/hero.js
+++ b/src/data/hero.js
@@ -2,5 +2,5 @@ export const hero = {
   title: "Hi, I'm Yesid",
   role: "An App Developer ",
   description:
-    "from Montreal, Canada. I aspire to help others offer great solutions with a strong focus on user events and maintainable code.",
+    "from Montreal, Canada. I aspire to help others offer great solutions with a strong focus on user events and maintainable code. Currently seeking full-time opportunities.",
 };


### PR DESCRIPTION
## Summary
- Highlight openness to full-time roles in hero section
- Adjust contact section to invite job opportunity discussions
- Update timeline to reflect pursuit of full-time positions instead of freelancing
------
https://chatgpt.com/codex/tasks/task_e_68bf15e5cda4832e9b3b3144171f2c70